### PR TITLE
Put original string instead of foldedCase

### DIFF
--- a/src/Data/Binary/Instances/CaseInsensitive.hs
+++ b/src/Data/Binary/Instances/CaseInsensitive.hs
@@ -8,4 +8,4 @@ import qualified Data.CaseInsensitive as CI
 
 instance (CI.FoldCase a, Binary a) => Binary (CI.CI a) where
     get = fmap CI.mk get
-    put = put . CI.foldedCase
+    put = put . CI.original


### PR DESCRIPTION
The foldedCase is derivative of the original string, while the latter
is unique. So, putting foldedCase instead of original string leads to
loss of data, while getting from the original string must always restore
CI object correctly as it has been built from the original string.

Probably it should also fix weird cases like in issue #7.

My own case was restoring serialized ResponseHeaders from
Network.HTTP.Types. Say, putting Custom-Header and restoring it later
makes it custom-header (when I take it with original), while when
putting original string it restores correctly as Custom-Header (when I
take it with original).